### PR TITLE
fix kabooming by kerbal

### DIFF
--- a/source/Kaboom.cs
+++ b/source/Kaboom.cs
@@ -1,4 +1,5 @@
 ﻿using KSP.Localization;
+using UnityEngine;
 
 namespace Kaboom
 {
@@ -7,11 +8,10 @@ namespace Kaboom
     /// </summary>
     public class ModuleKaboom : PartModule
     {
-        [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = true, guiName = "Kaboom delay",
-            groupName = "Kaboom", groupStartCollapsed = true,
-            guiUnits = " Seconds"),
+        [KSPField(isPersistant = true,
+            guiName = "Kaboom delay", groupName = "Kaboom", groupStartCollapsed = true, guiUnits = " Seconds",
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, guiActiveEditor = true),
             UI_FloatRange(minValue = 0f, maxValue = 30f, stepIncrement = 1f)]
-
         public float delay = 0;
 
         [KSPField(isPersistant = true)]
@@ -24,7 +24,8 @@ namespace Kaboom
         public bool isGlued = false;
 
         [KSPEvent(groupName = "Kaboom",
-            guiActive = true, guiActiveEditor = true, active = true, guiActiveUncommand = true)]
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, guiActiveEditor = true,
+            active = true, guiActiveUncommand = true)]
         public void GluedEvent()
         {
             isGlued = !isGlued;
@@ -40,14 +41,16 @@ namespace Kaboom
         }
 
         [KSPEvent(guiName = "Kaboom!", groupName = "Kaboom",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, active = true, guiActiveUncommand = true)]
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f,
+            active = true, guiActiveUncommand = true)]
         public void KaboomEvent()
         {
             KaboomIt();
         }
 
         [KSPEvent(guiName = "Cancel Kaboom!", groupName = "Kaboom",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, active = false, guiActiveUncommand = true)]
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, 
+            active = false, guiActiveUncommand = true)]
         public void CancelKaboomEvent()
         {
             CancelKaboomIt();
@@ -66,7 +69,6 @@ namespace Kaboom
                 Fields["delay"].group.displayName = "Kaboom Safety Cover";
 
             GUITextUpdate();
-
         }
 
         private void KaboomIt()

--- a/source/Kaboom.cs
+++ b/source/Kaboom.cs
@@ -10,7 +10,7 @@ namespace Kaboom
     {
         [KSPField(isPersistant = true,
             guiName = "Kaboom delay", groupName = "Kaboom", groupStartCollapsed = true, guiUnits = " Seconds",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, guiActiveEditor = true),
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 10f, guiActiveEditor = true),
             UI_FloatRange(minValue = 0f, maxValue = 30f, stepIncrement = 1f)]
         public float delay = 0;
 
@@ -18,7 +18,7 @@ namespace Kaboom
         public bool isGlued = false;
 
         [KSPEvent(groupName = "Kaboom",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, guiActiveEditor = true,
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 10f, guiActiveEditor = true,
             active = true, guiActiveUncommand = true)]
         public void GluedEvent()
         {
@@ -35,7 +35,7 @@ namespace Kaboom
         }
 
         [KSPEvent(guiName = "Kaboom!", groupName = "Kaboom",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f,
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 10f,
             active = true, guiActiveUncommand = true)]
         public void KaboomEvent()
         {
@@ -43,7 +43,7 @@ namespace Kaboom
         }
 
         [KSPEvent(guiName = "Cancel Kaboom!", groupName = "Kaboom",
-            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 5f, 
+            guiActive = true, guiActiveUnfocused = true, unfocusedRange = 10f, 
             active = false, guiActiveUncommand = true)]
         public void CancelKaboomEvent()
         {

--- a/source/Repo-Kaboom112.csproj
+++ b/source/Repo-Kaboom112.csproj
@@ -58,6 +58,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Version.tt</DependentUpon>
     </Compile>
+    <Compile Include="Support\Settings.cs" />
+    <Compile Include="Welding\Welding.cs" />
+    <Compile Include="Welding\WeldingData.cs" />
+    <Compile Include="Welding\WeldingUtilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />


### PR DESCRIPTION
 * Invoke() with delay instead of OnUpdate(). 
      * scale delay on timewarp. Parts are able to kaboom while timewarp
 * fix decoupling of decouplers on glued kaboom
 * fix missing title and fields for kabooming by kerbal within range
      *  increase range to 10, same as EVA Construction Mode range

![](https://i.imgur.com/gFaxXfN.jpeg)


